### PR TITLE
Add missing exceptions header

### DIFF
--- a/grasshopper.hpp
+++ b/grasshopper.hpp
@@ -6,6 +6,7 @@
 #include <utility>
 #include <cstdlib>
 #include <cstdint>
+#include <stdexcept>
 #include <immintrin.h>
 
 template<typename T>


### PR DESCRIPTION
[`std::length_error`](https://en.cppreference.com/w/cpp/error/length_error) is defined in `<stdexcept>`. So this header should be implicitly included, otherwise clang exits with error:

```
clang++ -std=c++17 -Wall -Wextra -msse -mavx2 -O3 -DNDEBUG -c grasshopper.cpp -o grasshopper.o In file included from grasshopper.cpp:8:
./grasshopper.hpp:24:24: error: no member named 'length_error' in namespace 'std'
   24 |             throw std::length_error("AlignedAllocator::allocate() - integer overflow");
      |                   ~~~~~^
1 error generated.
```